### PR TITLE
0.10.1 bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,16 @@ Changelog:
 
 _(not counting the ridiculous amount of edits after each update)_
 
+
+*0.10.1*
+
+- *exporter*:
+- fixed scaling for static mesh exports, not working properly for armatures at the moment
+- the exporter now detects the root bone of any parented armature, removing the need to manually enter root bone name
+- fixed an export error that occured when exporting a mesh twice (the normals list was getting cleared if in vertex mode)
+- *editor*:
+- fixed Default auto-generation method
+
 *0.10.0*
 
 - replaced broken init file (Blender should recognize the addon again)

--- a/udk_fbx_tools/__init__.py
+++ b/udk_fbx_tools/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
 	"name": "UE FBX Normals Tools",
 	"author": "Andreas Wiehn (isathar)",
-	"version": (0, 10, 0),
+	"version": (0, 10, 1),
 	"blender": (2, 70, 0),
 	"location": "View3D > Toolbar",
 	"description": "Adds an editor for vertex normals and an exporter "

--- a/udk_fbx_tools/export_menu.py
+++ b/udk_fbx_tools/export_menu.py
@@ -110,11 +110,6 @@ class ExportFBX(bpy.types.Operator, ExportHelper):
 				   ),
 			default='NONE',
 			)
-	export_rootbonename = StringProperty(
-			name="Root Bone",
-			description="The name of your skeleton's root bone",
-			default='b_root',
-			)
 	use_armature_deform_only = BoolProperty(
 			name="Only Deform Bones",
 			description="Only write deforming bones",
@@ -195,7 +190,7 @@ class ExportFBX(bpy.types.Operator, ExportHelper):
 		
 		global_matrix = (global_matrix * axis_conversion(to_forward=self.axis_forward,to_up=self.axis_up,).to_4x4())
 		
-		keywords = self.as_keywords(ignore=("global_scale","check_existing","filter_glob","axis_forward","axis_up"))
+		keywords = self.as_keywords(ignore=("check_existing","filter_glob","axis_forward","axis_up"))
 		keywords["global_matrix"] = global_matrix
 		
 		from . import export_fbx


### PR DESCRIPTION
- fixed scaling for static mesh exports, not working properly for
armatures at the moment
- the exporter now detects the root bone of any parented armature,
removing the need to manually enter root bone name
- fixed an export error that occured when exporting a mesh twice (the
normals list was getting cleared if in vertex mode)
- fixed Default auto-generation method